### PR TITLE
Fix battery drain for mobile clients

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN sed -i -e 's/#mail_plugins = \$mail_plugins/mail_plugins = \$mail_plugins si
 RUN sed -i -e 's/^.*lda_mailbox_autocreate.*/lda_mailbox_autocreate = yes/g' /etc/dovecot/conf.d/15-lda.conf
 RUN sed -i -e 's/^.*lda_mailbox_autosubscribe.*/lda_mailbox_autosubscribe = yes/g' /etc/dovecot/conf.d/15-lda.conf
 RUN sed -i -e 's/^.*postmaster_address.*/postmaster_address = '${POSTMASTER_ADDRESS:="postmaster@domain.com"}'/g' /etc/dovecot/conf.d/15-lda.conf
+RUN sed -i 's/#imap_idle_notify_interval = 2 mins/imap_idle_notify_interval = 29 mins/' /etc/dovecot/conf.d/20-imap.conf
 COPY target/dovecot/auth-passwdfile.inc /etc/dovecot/conf.d/
 COPY target/dovecot/??-*.conf /etc/dovecot/conf.d/
 


### PR DESCRIPTION
Regarding too frequent IDLE notifications mobile clients like k9mail have a massive battery drain.
More info:
https://github.com/k9mail/k-9/issues/1290
https://peterkieser.com/2011/03/25/androids-k-9-mail-battery-life-and-dovecots-push-imap/